### PR TITLE
v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # svelte-tags-input changelog
 
-# 2.6.0
-* `minChars` minimum length of search text to show auto-complete list ([#28](https://github.com/agustinl/svelte-tags-input/pull/28))
+## 2.6.0
+* Added `minChars` option: minimum length of search text to show auto-complete list ([#28](https://github.com/agustinl/svelte-tags-input/issues/28))
 * Change homepage in package.json
-* Prevent writing if the maximum number of tags allowed is reached ([#25](https://github.com/agustinl/svelte-tags-input/pull/25))
+* Prevent writing if the maximum number of tags allowed is reached ([#25](https://github.com/agustinl/svelte-tags-input/issues/25))
 * Highlight the matching characters in the auto-complete list
-* Fix bug ([#30](https://github.com/agustinl/svelte-tags-input/pull/30))
+* Fix bug ([#30](https://github.com/agustinl/svelte-tags-input/issues/30))
 
 ## 2.5.1
-* Fix deleting last tag while input is not empty ([#26](https://github.com/agustinl/svelte-tags-input/pull/26))
+* Fix deleting last tag while input is not empty ([#26](https://github.com/agustinl/svelte-tags-input/issues/26))
 
 ## 2.5.0
 * Added the `on:blur` event
@@ -31,7 +31,7 @@
 * Added a unique ID for each input
 
 ## 2.2.0
-* Improve auto-complete ([#10](https://github.com/agustinl/svelte-tags-input/pull/10))
+* Improve auto-complete ([#10](https://github.com/agustinl/svelte-tags-input/issues/10))
 
 ## 2.1.0
 * Added FAQs
@@ -40,14 +40,14 @@
 
 ## 2.0.1
 * Added CSS override instructions to documentation
-* Added link to modify the current list of tags ([#5](https://github.com/agustinl/svelte-tags-input/pull/5)) to documentation 
+* Added link to modify the current list of tags ([#5](https://github.com/agustinl/svelte-tags-input/issues/5)) to documentation 
 
 ## 2.0.0
-* Added auto complete feature ([#4](https://github.com/agustinl/svelte-tags-input/pull/4))
+* Added auto complete feature ([#4](https://github.com/agustinl/svelte-tags-input/issues/4))
 * Added vendor prefixes to CSS
 
 ## 1.0.16
 * Added paste or drop tag or group of tags
 
 ## 1.0.15
-* Blocking adding empty tag ([#1](https://github.com/agustinl/svelte-tags-input/pull/1))
+* Blocking adding empty tag ([#1](https://github.com/agustinl/svelte-tags-input/issues/1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # svelte-tags-input changelog
 
+# 2.6.0
+* `minChars` minimum length of search text to show auto-complete list ([#28](https://github.com/agustinl/svelte-tags-input/pull/28))
+* Change homepage in package.json
+* Prevent writing if the maximum number of tags allowed is reached ([#25](https://github.com/agustinl/svelte-tags-input/pull/25))
+* Highlight the matching characters in the auto-complete list
+* Fix bug ([#30](https://github.com/agustinl/svelte-tags-input/pull/30))
+
 ## 2.5.1
 * Fix deleting last tag while input is not empty ([#26](https://github.com/agustinl/svelte-tags-input/pull/26))
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ import Tags from "svelte-tags-input";
 | maxTags | `Array` | `false` | Set maximum number of tags |
 | onlyUnique | `Boolean` | `false` | Set the entered tags to be unique |
 | placeholder | `String` | `false` | Set a placeholder |
-| autoComplete | `Array` | `false` | Set an array of elements to create a autocomplete dropdown |
+| autoComplete | `Array` | `false` | Set an array of elements to create a auto-complete dropdown |
 | name | `String` | `svelte-tags-input` | Set a `name` attribute |
 | id | `String` | Random Unique ID | Set a `id` attribute |
 | allowBlur | `Boolean` | `false` | Enable add tag when input blur |
 | disable | `Boolean` | `false` | Disable input |
+| minChars | `Number` | `1` | Minimum length of search text to show auto-complete list |
 
 ##### [A complete list of key codes](https://keycode.info/)
 
@@ -88,6 +89,7 @@ const countryList = [
     id={"custom-id"}
     allowBlur={true}
     disable={false} // Just to illustrate. No need to declare it if it's false.
+    minChars={3}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 <div align="center">Svelte tags input is a component to use with Svelte and easily enter tags and customize some options</div>
 <br />
 <p align="center">
-[![License: MIT](https://img.shields.io/npm/v/svelte-tags-input.svg)](https://www.npmjs.com/package/svelte-tags-input)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![MadeWithSvelte.com shield](https://madewithsvelte.com/storage/repo-shields/2151-shield.svg)](https://madewithsvelte.com/p/svelte-tags-input/shield-link)
+<p align="center">
+<a href="https://www.npmjs.com/package/svelte-tags-input"><img src="https://img.shields.io/npm/v/svelte-tags-input.svg"/></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg"/></a>
+<a href="https://madewithsvelte.com/p/svelte-tags-input/shield-link"><img src="https://madewithsvelte.com/storage/repo-shields/2151-shield.svg"/></a>
 </p>
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
+<p align="center"><a href="https://svelte-tags-input.now.sh/"><img src="https://svelte-tags-input.now.sh/readme-image.png" alt="Svelte Tags Input"/></a></p>
 <h1 align="center">
     svelte-tags-input
 </h1>
 <div align="center">Svelte tags input is a component to use with Svelte and easily enter tags and customize some options</div>
 <br />
-
+<p align="center">
 [![License: MIT](https://img.shields.io/npm/v/svelte-tags-input.svg)](https://www.npmjs.com/package/svelte-tags-input)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![MadeWithSvelte.com shield](https://madewithsvelte.com/storage/repo-shields/2151-shield.svg)](https://madewithsvelte.com/p/svelte-tags-input/shield-link)
+</p>
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <div align="center">Svelte tags input is a component to use with Svelte and easily enter tags and customize some options</div>
 <br />
 <p align="center">
-<p align="center">
 <a href="https://www.npmjs.com/package/svelte-tags-input"><img src="https://img.shields.io/npm/v/svelte-tags-input.svg"/></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg"/></a>
 <a href="https://madewithsvelte.com/p/svelte-tags-input/shield-link"><img src="https://madewithsvelte.com/storage/repo-shields/2151-shield.svg"/></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-tags-input",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-tags-input",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-tags-input",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Svelte tags input is a component to use with Svelte and easily enter tags and customize some functions.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -22,7 +22,7 @@
     "type": "git",
     "url": "https://github.com/agustinl/svelte-tags-input"
   },
-  "author": "agustinl (https://agustinl.dev)",
+  "author": "Agustin Lautaro <aencaje@gmail.com>",
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.1",
@@ -31,7 +31,7 @@
     "rollup-plugin-svelte": "^5.1.1",
     "svelte": "^3.16.7"
   },
-  "homepage": "https://svelte-tags-input-example.now.sh/",
+  "homepage": "https://svelte-tags-input.now.sh/",
   "bugs": {
     "url": "https://github.com/agustinl/svelte-tags-input/issues"
   },

--- a/package.json
+++ b/package.json
@@ -4,19 +4,16 @@
   "description": "Svelte tags input is a component to use with Svelte and easily enter tags and customize some functions.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "svelte": "src/index.js",
+  "svelte": "src/Tags.svelte",
   "scripts": {
     "build": "rollup -c",
     "prepare": "npm run build",
     "dev": "rollup -c -w"
   },
   "keywords": [
-    "input",
-    "tags",
     "svelte",
-    "component",
-    "javascript",
-    "sapper"
+    "tags",
+    "input"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Svelte tags input is a component to use with Svelte and easily enter tags and customize some functions.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "svelte": "src/Tags.svelte",
+  "svelte": "src/index.js",
   "scripts": {
     "build": "rollup -c",
     "prepare": "npm run build",

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -277,7 +277,9 @@ function uniqueID() {
 {/if}
 
 <style>
-/* main */
+
+
+/* CSS svelte-tags-input */
 
 .svelte-tags-input,
 .svelte-tags-input-tag,

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -277,8 +277,6 @@ function uniqueID() {
 {/if}
 
 <style>
-
-
 /* CSS svelte-tags-input */
 
 .svelte-tags-input,

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -4,6 +4,9 @@ import { createEventDispatcher } from 'svelte';
 const dispatch = createEventDispatcher();
 let tag = "";
 let arrelementsmatch = [];
+let regExpEscape = (s) => {
+  return s.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&")
+}
 
 export let tags;
 export let addKeys;
@@ -19,6 +22,7 @@ export let name;
 export let id;
 export let allowBlur;
 export let disable;
+export let minChars;
 
 $: tags = tags || [];
 $: addKeys = addKeys || [13];
@@ -34,8 +38,11 @@ $: name = name || "svelte-tags-input";
 $: id = id || uniqueID();
 $: allowBlur = allowBlur || false;
 $: disable = disable || false;
+$: minChars = minChars || 1;
 
 $: matchsID = id + "_matchs";
+
+let storePlaceholder = placeholder;
 
 function setTag(input) {
     
@@ -48,7 +55,7 @@ function setTag(input) {
                 
                 switch (input.keyCode) {
                 case 9:
-                    // Add first item of autocomplete list on TAB
+                    // TAB add first element on the autoComplete list
                     if (autoComplete && document.getElementById(matchsID)) {                        
                         addTag(document.getElementById(matchsID).querySelectorAll("li")[0].textContent);
                     } else {
@@ -76,11 +83,11 @@ function setTag(input) {
         });
     }
     
-    // If KEYDOWN focus on first element of the autocomplete
+    // ArrowDown : focus on first element of the autocomplete
     if (input.keyCode === 40 && autoComplete && document.getElementById(matchsID)) {
         event.preventDefault();
         document.getElementById(matchsID).querySelector("li:first-child").focus();
-    } // If KEYUP focus on last element of the autocomplete
+    } // ArrowUp : focus on last element of the autocomplete
     else if (input.keyCode === 38 && autoComplete && document.getElementById(matchsID)) {
         event.preventDefault();
         document.getElementById(matchsID).querySelector("li:last-child").focus();
@@ -104,9 +111,15 @@ function addTag(currentTag) {
 		tags: tags
     });
     
-    // After add a tag, hide autocomplete list and focus on svelte tags input
+    // Hide autocomplete list
+    // Focus on svelte tags input
     arrelementsmatch = [];
     document.getElementById(id).focus();
+
+    if (maxTags && tags.length == maxTags) {
+        document.getElementById(id).readOnly = true;
+        placeholder = "";
+    };
 
 }
 
@@ -117,10 +130,13 @@ function removeTag(i) {
 
     dispatch('tags', {
 		tags: tags
-	});
+	});    
     
-    // After add a tag, hide autocomplete list and focus on svelte tags input
+    // Hide autocomplete list
+    // Focus on svelte tags input
     arrelementsmatch = [];
+    document.getElementById(id).readOnly = false;
+    placeholder = storePlaceholder;
     document.getElementById(id).focus();
 
 }
@@ -147,9 +163,12 @@ function onDrop(e){
 
 }
 
-function onBlur(input){
+function onBlur(tag){
 
-    if(allowBlur) addTag(input);
+    if (!document.getElementById(matchsID) && allowBlur) {
+        event.preventDefault();
+        addTag(tag);
+    }
     
 }
 
@@ -167,7 +186,7 @@ function getClipboardData(e) {
 }
 
 function splitTags(data) {
-    return data.split(splitWith).map(d => d.trim());    
+    return data.split(splitWith).map(tag => tag.trim());    
 }
 
 function getMatchElements(input) {
@@ -176,18 +195,22 @@ function getMatchElements(input) {
     
     var value = input.target.value;
     
-    // Close auto complete list if press ESC or there is no value
-    if (value == "" || input.keyCode === 27) {
+    // Escape
+    if (value == "" || input.keyCode === 27 || value.length < minChars ) {
         arrelementsmatch = [];
         return;
     }
 
-    var matchs = autoComplete.filter(e => e.toLowerCase().includes(value.toLowerCase())); 
+    var matchs = autoComplete.filter(e => e.toLowerCase().includes(value.toLowerCase())).map(matchTag => {
+            return {
+                label: matchTag,
+                search: matchTag.replace(RegExp(regExpEscape(value.toLowerCase()), 'i'), "<strong>$&</strong>")
+            }
+        });; 
 
-    // Show autocomplete list without tags already added
     if (onlyUnique === true) {
-        matchs = matchs.filter(x => !tags.includes(x));
-    }   
+        matchs = matchs.filter(tag => !tags.includes(tag.label));
+    }
 
     arrelementsmatch = matchs;
 }
@@ -198,23 +221,27 @@ function navigateAutoComplete(autoCompleteIndex, autoCompleteLength, autoComplet
     
     event.preventDefault();
 
-    if (event.keyCode === 40) { // If KEYDOWN
-        // If it is the last element on the list, go to the first
+    // ArrowDown
+    if (event.keyCode === 40) {
+        // Last element on the list ? Go to the first
         if (autoCompleteIndex + 1 === autoCompleteLength) {
             document.getElementById(matchsID).querySelector("li:first-child").focus();
             return;
         }
         document.getElementById(matchsID).querySelectorAll("li")[autoCompleteIndex + 1].focus();
-    } else if (event.keyCode === 38) { // If KEYUP
-        // If it is the first element on the list, go to the last
+    } else if (event.keyCode === 38) {
+        // ArrowUp
+        // First element on the list ? Go to the last
         if (autoCompleteIndex === 0) {
             document.getElementById(matchsID).querySelector("li:last-child").focus();
             return;
         }
         document.getElementById(matchsID).querySelectorAll("li")[autoCompleteIndex - 1].focus();
-    } else if (event.keyCode === 13) { // If ENTER addTag
+    } else if (event.keyCode === 13) { 
+        // Enter
         addTag(autoCompleteElement);
-    } else if (event.keyCode === 27) { // Close auto complete list if press ESC and focus in input
+    } else if (event.keyCode === 27) {
+        // Escape
         arrelementsmatch = [];
         document.getElementById(id).focus();
     }
@@ -226,7 +253,7 @@ function uniqueID() {
 
 </script>
 
-<div class="svelte-tags-input-layout {disable ? "sti-layout-disable" : ""}">
+<div class="svelte-tags-input-layout" class:sti-layout-disable={disable}>
     {#if tags.length > 0}
         {#each tags as tag, i}
             <span class="svelte-tags-input-tag">{tag}
@@ -236,14 +263,14 @@ function uniqueID() {
             </span>
         {/each}
     {/if}
-    <input type="text" id={id} name={name} bind:value={tag} on:keydown={setTag} on:keyup={getMatchElements} on:paste={onPaste} on:drop={onDrop} on:blur={() => onBlur(tag)} class="svelte-tags-input" placeholder={placeholder} disabled={disable}>
+    <input type="text" id={id} name={name} bind:value={tag} on:keydown={setTag} on:keyup={getMatchElements} on:paste={onPaste} on:drop={onDrop} on:blur={() => onBlur(tag)} class="svelte-tags-input" placeholder={placeholder} disabled={disable} >
 </div>
 
 {#if autoComplete && arrelementsmatch.length > 0}
     <div class="svelte-tags-input-matchs-parent">
         <ul id="{id}_matchs" class="svelte-tags-input-matchs">
-            {#each arrelementsmatch as element, i}
-                <li tabindex="-1" on:keydown={() => navigateAutoComplete(i, arrelementsmatch.length, element)} on:click={() => addTag(element)}>{element}</li>
+            {#each arrelementsmatch as element, index}
+                <li tabindex="-1" on:keydown={() => navigateAutoComplete(index, arrelementsmatch.length, element.label)} on:click={() => addTag(element.label)}>{@html element.search}</li>
             {/each}
         </ul>
     </div>


### PR DESCRIPTION
- [x] Added `minChars` option: minimum length of search text to show auto-complete list ([#28](https://github.com/agustinl/svelte-tags-input/pull/28))
- [x] Change homepage in package.json
- [x] Prevent writing if the maximum number of tags allowed is reached ([#25](https://github.com/agustinl/svelte-tags-input/pull/25))
- [x] Highlight the matching characters in the auto-complete list
- [x] Fix bug ([#30](https://github.com/agustinl/svelte-tags-input/pull/30))