### PR TITLE
Improve autocomplete

### DIFF
--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -233,6 +233,7 @@ async function getMatchElements(input) {
 
     if (!autoComplete) return;
 
+    let value = input.target.value;
     let autoCompleteValues = [];
     
     if (Array.isArray(autoComplete)) {
@@ -241,13 +242,12 @@ async function getMatchElements(input) {
             
     if (typeof autoComplete === 'function') {
         if(autoComplete.constructor.name === 'AsyncFunction') {
-            autoCompleteValues = await autoComplete()
+            autoCompleteValues = await autoComplete(value)
         } else {
-            autoCompleteValues = autoComplete()
+            autoCompleteValues = autoComplete(value)
         }
     }
     
-    var value = input.target.value;
     
     // Escape
     if (value == "" || input.keyCode === 27 || value.length < minChars ) {

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -21,6 +21,7 @@ export let splitWith;
 export let autoComplete;
 export let autoCompleteFilter;
 export let autoCompleteKey;
+export let autoCompleteMarkupKey;
 export let name;
 export let id;
 export let allowBlur;
@@ -43,6 +44,7 @@ $: allowDrop = allowDrop || false;
 $: splitWith = splitWith || ",";
 $: autoComplete = autoComplete || false;
 $: autoCompleteKey = autoCompleteKey || false;
+$: autoCompleteMarkupKey = autoCompleteMarkupKey || false;
 $: name = name || "svelte-tags-input";
 $: id = id || uniqueID();
 $: allowBlur = allowBlur || false;
@@ -230,6 +232,22 @@ function splitTags(data) {
     return data.split(splitWith).map(tag => tag.trim());    
 }
 
+function escapeHTML(string) {
+    const htmlEscapes = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#x27;',
+        '/': '&#x2F;'
+    };
+    return ('' + string).replace(/[&<>"'\/]/g, match => htmlEscapes[match]);
+}
+
+function buildMatchMarkup(search, value) {
+    return escapeHTML(value).replace(RegExp(regExpEscape(search.toLowerCase()), 'i'), "<strong>$&</strong>")
+}
+
 async function getMatchElements(input) {
 
     if (!autoComplete) return;
@@ -273,7 +291,8 @@ async function getMatchElements(input) {
         matchs = matchs.map(matchTag => {
             return {
                 label: matchTag,
-                search: matchTag[autoCompleteKey].replace(RegExp(regExpEscape(value.toLowerCase()), 'i'), "<strong>$&</strong>")
+                search: autoCompleteMarkupKey ? matchTag[autoCompleteMarkupKey] :
+                                                buildMatchMarkup(value, matchTag[autoCompleteKey])
             }
         });
 
@@ -285,7 +304,7 @@ async function getMatchElements(input) {
         matchs = matchs.map(matchTag => {
             return {
                 label: matchTag,
-                search: matchTag.replace(RegExp(regExpEscape(value.toLowerCase()), 'i'), "<strong>$&</strong>")
+                search: buildMatchMarkup(value, matchTag)
             }
         });
     }

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -247,7 +247,10 @@ async function getMatchElements(input) {
             autoCompleteValues = autoComplete(value)
         }
     }
-    
+
+    if(autoCompleteValues.constructor.name === 'Promise') {
+      autoCompleteValues = await autoCompleteValues;
+    }
     
     // Escape
     if (value == "" || input.keyCode === 27 || value.length < minChars ) {

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -29,6 +29,8 @@ export let onlyAutocomplete;
 export let labelText;
 export let labelShow;
 
+let layoutElement;
+
 $: tags = tags || [];
 $: addKeys = addKeys || [13];
 $: maxTags = maxTags || false;
@@ -193,7 +195,15 @@ function onDrop(e){
 
 }
 
+function onFocus(tag){
+
+    layoutElement.classList.add('focus');
+
+}
+
 function onBlur(tag){
+
+    layoutElement.classList.remove('focus');
 
     if (!document.getElementById(matchsID) && allowBlur) {
         event.preventDefault();
@@ -313,7 +323,7 @@ function uniqueID() {
 
 </script>
 
-<div class="svelte-tags-input-layout" class:sti-layout-disable={disable}>
+<div class="svelte-tags-input-layout" class:sti-layout-disable={disable} bind:this={layoutElement}>
     <label for={id} class={labelShow ? "" : "sr-only"}>{labelText}</label>
 
     {#if tags.length > 0}
@@ -339,6 +349,7 @@ function uniqueID() {
         on:keyup={getMatchElements}
         on:paste={onPaste}
         on:drop={onDrop}
+        on:focus={() => onFocus(tag)}
         on:blur={() => onBlur(tag)}
         class="svelte-tags-input"
         placeholder={placeholder}

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -19,6 +19,7 @@ export let allowPaste;
 export let allowDrop;
 export let splitWith;
 export let autoComplete;
+export let autoCompleteFilter;
 export let autoCompleteKey;
 export let name;
 export let id;
@@ -257,6 +258,8 @@ async function getMatchElements(input) {
         arrelementsmatch = [];
         return;
     }
+
+    let matchs = autoCompleteValues
     
     if (typeof autoCompleteValues[0] === 'object' && autoCompleteValues !== null) {
         
@@ -264,7 +267,10 @@ async function getMatchElements(input) {
             return console.error("'autoCompleteValue' is necessary if 'autoComplete' result is an array of objects");
         }
 
-        var matchs = autoCompleteValues.filter(e => e[autoCompleteKey].toLowerCase().includes(value.toLowerCase())).map(matchTag => {
+        if(autoCompleteFilter !== false) {
+            matchs = autoCompleteValues.filter(e => e[autoCompleteKey].toLowerCase().includes(value.toLowerCase()))
+        }
+        matchs = matchs.map(matchTag => {
             return {
                 label: matchTag,
                 search: matchTag[autoCompleteKey].replace(RegExp(regExpEscape(value.toLowerCase()), 'i'), "<strong>$&</strong>")
@@ -273,7 +279,10 @@ async function getMatchElements(input) {
 
 
     } else {
-        var matchs = autoCompleteValues.filter(e => e.toLowerCase().includes(value.toLowerCase())).map(matchTag => {
+        if(autoCompleteFilter !== false) {
+            matchs = autoCompleteValues.filter(e => e.toLowerCase().includes(value.toLowerCase()))
+        }
+        matchs = matchs.map(matchTag => {
             return {
                 label: matchTag,
                 search: matchTag.replace(RegExp(regExpEscape(value.toLowerCase()), 'i'), "<strong>$&</strong>")


### PR DESCRIPTION
Use case :

- autocomplete e-mail address from a server-side contact database.
- autocompleted values look like "Name <email@example.com>" and need to be HTML escaped
- autocomplete is better performed server-side with search on first name, last name or e-mail (not just string prefix)
- ability to customize the markup (show photo or other data) can be useful too