### PR TITLE
Fix onBlur bug

### DIFF
--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -199,7 +199,7 @@ function onFocus() {
     layoutElement.classList.add('focus');
 }
 
-function onBlur(tag) {
+function onBlur(e, tag) {
     layoutElement.classList.remove('focus');
 
     if (!document.getElementById(matchsID) && allowBlur) {
@@ -378,7 +378,7 @@ function uniqueID() {
         on:paste={onPaste}
         on:drop={onDrop}
         on:focus={onFocus}
-        on:blur={() => onBlur(tag)}
+        on:blur={(e) => onBlur(e, tag)}
         on:click={onClick}
         class="svelte-tags-input"
         placeholder={placeholder}


### PR DESCRIPTION
With the current code, `onBlur` will always fail since it cannot access the `e` BlurEvent object from the handler. This fix passes the event object down to the onBlur function. Fixes #58 