### PR TITLE
Fix issues for sveltecms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,9 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "svelte-tags-input",
       "version": "2.9.2",
       "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.1.1"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^18.0.0",
         "rollup": "^2.45.2",
@@ -82,17 +80,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/balanced-match": {
@@ -503,11 +490,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
     },
     "balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
   "homepage": "https://svelte-tags-input.vercel.app/",
   "bugs": {
     "url": "https://github.com/agustinl/svelte-tags-input/issues"
-  },
-  "dependencies": {
-    "acorn": "^8.1.1"
   }
 }

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -210,10 +210,20 @@ function onFocus() {
 function onBlur(e, tag) {
     layoutElement.classList.remove('focus');
 
-    if (!document.getElementById(matchsID) && allowBlur) {
-        e.preventDefault();
-        addTag(tag);
+    if (allowBlur) {
+        // A match is highlighted
+        if (arrelementsmatch.length && autoCompleteIndex > -1) {
+            addTag(arrelementsmatch?.[autoCompleteIndex]?.label)
+        }
+        // There is no match, but we may add a new tag
+        else if (!arrelementsmatch.length) {
+            e.preventDefault()
+            addTag(tag)
+        }
     }
+
+    arrelementsmatch = []
+    autoCompleteIndex = -1
 }
 
 function onClick() {    

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -350,7 +350,7 @@ function uniqueID() {
                     {tag[autoCompleteKey]}
                 {/if}
                 {#if !disable}
-                <span class="svelte-tags-input-tag-remove" on:click={() => removeTag(i)}> &#215;</span>
+                <span class="svelte-tags-input-tag-remove" on:pointerdown={() => removeTag(i)}> &#215;</span>
                 {/if}
             </span>
         {/each}
@@ -366,7 +366,7 @@ function uniqueID() {
         on:drop={onDrop}
         on:focus={onFocus}
         on:blur={(e) => onBlur(e, tag)}
-        on:click={onClick}
+        on:pointerdown={onClick}
         class="svelte-tags-input"
         placeholder={placeholder}
         disabled={disable}

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -227,7 +227,7 @@ function onBlur(e, tag) {
 }
 
 function onClick() {    
-    minChars == 0 && getMatchElements();
+    (!minChars || minChars == 0) && getMatchElements();
 }
 
 
@@ -381,7 +381,7 @@ function uniqueID() {
                 <li
                     tabindex="-1"
                     class:focus={index === autoCompleteIndex}
-                    on:click={() => addTag(element.label)}>
+                    on:pointerdown|preventDefault={() => addTag(element.label)}>
                         {@html element.search}
                     </li>
             {/each}

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -370,6 +370,7 @@ function uniqueID() {
         class="svelte-tags-input"
         placeholder={placeholder}
         disabled={disable}
+        autocomplete="off"
     >
 </div>
 

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -5,6 +5,7 @@ const dispatch = createEventDispatcher();
 
 let tag = "";
 let arrelementsmatch = [];
+let autoCompleteIndex = -1;
 let regExpEscape = (s) => {
   return s.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&")
 }
@@ -82,7 +83,7 @@ function setTag(e) {
                     break;
                 } */
                 if (autoComplete && document.getElementById(matchsID)) {
-                    addTag(document.getElementById(matchsID).querySelectorAll("li")[0].textContent);
+                    addTag(arrelementsmatch?.[autoCompleteIndex]?.label);
                 } else {
                     addTag(currentTag);
                 }
@@ -110,12 +111,18 @@ function setTag(e) {
     
     // ArrowDown : focus on first element of the autocomplete
     if (e.keyCode === 40 && autoComplete && document.getElementById(matchsID)) {
-        e.preventDefault();
-        document.getElementById(matchsID).querySelector("li:first-child").focus();
-    } // ArrowUp : focus on last element of the autocomplete
-    else if (e.keyCode === 38 && autoComplete && document.getElementById(matchsID)) {
-        e.preventDefault();
-        document.getElementById(matchsID).querySelector("li:last-child").focus();
+        // Last element on the list ? Go to the first
+        if (autoCompleteIndex + 1 === arrelementsmatch.length) autoCompleteIndex = 0
+        else autoCompleteIndex++
+    } else if (e.keyCode === 38) {
+        // ArrowUp
+        // First element on the list ? Go to the last
+        if (autoCompleteIndex <= 0) autoCompleteIndex = arrelementsmatch.length - 1
+        else autoCompleteIndex--
+    } else if (e.keyCode === 27) {
+        // Escape
+        arrelementsmatch = [];
+        document.getElementById(id).focus();
     }
 
 }
@@ -150,6 +157,7 @@ function addTag(currentTag) {
     // Hide autocomplete list
     // Focus on svelte tags input
     arrelementsmatch = [];
+    autoCompleteIndex = -1;
     document.getElementById(id).focus();
 
     if (maxTags && tags.length == maxTags) {
@@ -313,38 +321,6 @@ async function getMatchElements(input) {
     arrelementsmatch = matchs;
 }
 
-function navigateAutoComplete(e, autoCompleteIndex, autoCompleteLength, autoCompleteElement) {
-
-    if (!autoComplete) return;
-    
-    e.preventDefault();
-
-    // ArrowDown
-    if (e.keyCode === 40) {
-        // Last element on the list ? Go to the first
-        if (autoCompleteIndex + 1 === autoCompleteLength) {
-            document.getElementById(matchsID).querySelector("li:first-child").focus();
-            return;
-        }
-        document.getElementById(matchsID).querySelectorAll("li")[autoCompleteIndex + 1].focus();
-    } else if (e.keyCode === 38) {
-        // ArrowUp
-        // First element on the list ? Go to the last
-        if (autoCompleteIndex === 0) {
-            document.getElementById(matchsID).querySelector("li:last-child").focus();
-            return;
-        }
-        document.getElementById(matchsID).querySelectorAll("li")[autoCompleteIndex - 1].focus();
-    } else if (e.keyCode === 13) { 
-        // Enter
-        addTag(autoCompleteElement);
-    } else if (e.keyCode === 27) {
-        // Escape
-        arrelementsmatch = [];
-        document.getElementById(id).focus();
-    }
-}
-
 function uniqueID() {
     return 'sti_' + Math.random().toString(36).substring(2, 11);
 };
@@ -392,7 +368,7 @@ function uniqueID() {
             {#each arrelementsmatch as element, index}
                 <li
                     tabindex="-1"
-                    on:keydown={(e) => navigateAutoComplete(e, index, arrelementsmatch.length, element.label)}
+                    class:focus={index === autoCompleteIndex}
                     on:click={() => addTag(element.label)}>
                         {@html element.search}
                     </li>
@@ -508,7 +484,7 @@ function uniqueID() {
 }
 
 .svelte-tags-input-matchs li:hover,
-.svelte-tags-input-matchs li:focus {
+.svelte-tags-input-matchs li.focus {
     background:#000;
     color:#FFF;
     outline:none;

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -257,6 +257,7 @@ function buildMatchMarkup(search, value) {
 async function getMatchElements(input) {
 
     if (!autoComplete) return;
+    if (maxTags && tags.length >= maxTags) return;
     
     let value = input ? input.target.value : "";
     let autoCompleteValues = [];

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -429,6 +429,11 @@ function uniqueID() {
     border: solid 1px #000;    
 }
 
+.svelte-tags-input-layout:focus-within {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+}
+
 /* svelte-tags-input */
 
 .svelte-tags-input {


### PR DESCRIPTION
I've come across a few issues that prevent me using this as-is for SvelteCMS, and I'd love to help fix them if possible.

The major change here is that instead of navigating through the matches list using `li.focus()` this PR keeps the focus in svelte-tags-input's text input, and navigates matches using an index variable (`autoCompleteIndex`) and the `arrelementsmatch` array. I don't think this should change any other functionality. This major change is in the first commit fixing #64, which is the most critical issue.

Thank you for this excellent Svelte component, the functionality is really fantastic.