### PR TITLE
fix: Tag a11y events warning

### DIFF
--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -426,8 +426,8 @@ function uniqueID() {
 /* svelte-tags-input */
 
 .svelte-tags-input {
-    /* Use parent background */
-    background: inherit;
+    /* Parent handles background */
+    background: unset;
     -webkit-box-flex: 1;
         -ms-flex: 1;
             flex: 1; 

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -333,7 +333,7 @@ function uniqueID() {
 
     {#if tags.length > 0}
         {#each tags as tag, i}
-            <span class="svelte-tags-input-tag" on:click={onTagClick(tag)}>
+            <button class="svelte-tags-input-tag" on:click={onTagClick(tag)}>
                 {#if typeof tag === 'string'}
                     {tag}
                 {:else}
@@ -342,7 +342,7 @@ function uniqueID() {
                 {#if !disable && !readonly}
                     <span class="svelte-tags-input-tag-remove" on:pointerdown={() => removeTag(i)}> &#215;</span>
                 {/if}
-            </span>
+            </button>
         {/each}
     {/if}
     <input
@@ -441,12 +441,15 @@ function uniqueID() {
 /* svelte-tags-input-tag */
 
 .svelte-tags-input-tag {
+    cursor: text;
     display:-webkit-box;
     display:-ms-flexbox;
     display:flex;
     white-space: nowrap;
+    user-select: text;
     list-style:none;
     background: #000;
+    border: none;
     color: #FFF;
     border-radius: 2px;
     margin-right: 5px;

--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -426,6 +426,8 @@ function uniqueID() {
 /* svelte-tags-input */
 
 .svelte-tags-input {
+    /* Use parent background */
+    background: inherit;
     -webkit-box-flex: 1;
         -ms-flex: 1;
             flex: 1; 


### PR DESCRIPTION
This change ensures tags are interactive elements, in order to avoid a11y issues as latest versions of Svelte are quite strict about this.
```
A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.
```
Changing it to button and removing default styles seems more appropriate than adding events as span is not focusable either and key events would be useless.

Also, to make styling easier input background was changed to unset and parent will handle it as it's supposed to.