### PR TITLE
fix: Prevent tags from submitting form on click

### DIFF
--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -340,7 +340,7 @@ function uniqueID() {
 
     {#if tags.length > 0}
         {#each tags as tag, i}
-            <button class="svelte-tags-input-tag" on:click={onTagClick(tag)}>
+            <button type="button" class="svelte-tags-input-tag" on:click={onTagClick(tag)}>
                 {#if typeof tag === 'string'}
                     {tag}
                 {:else}


### PR DESCRIPTION
This is an omission from my previous PR. If input is nested inside an html form, clicking upon a tag will submit the form.
Setting type to `button` should fix this.