### PR TITLE
Fix tag button on:click

### DIFF
--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -370,7 +370,7 @@ function uniqueID() {
 
     {#if tags.length > 0}
         {#each tags as tag, i}
-            <button type="button" class="svelte-tags-input-tag" on:click={onTagClick(tag)}>
+            <button type="button" class="svelte-tags-input-tag" on:click={() => onTagClick(tag)}>
                 {#if typeof tag === 'string'}
                     {tag}
                 {:else}


### PR DESCRIPTION
Current use results in:
```
`click` handler at node_modules/svelte-tags-input/src/Tags.svelte:373:74 should be a function. Did you mean to add a leading `() =>`?
warn @ client.js:2711
event_handler_invalid @ warnings.js:42
apply @ events.js:318
(anonymous) @ Tags.svelte:380
(anonymous) @ events.js:66
without_reactive_context @ shared.js:44
target_handler @ events.js:65Understand this warningAI
```