### PR TITLE
Fix autoCompleteFilter fake boolean bug

### DIFF
--- a/src/Tags.svelte
+++ b/src/Tags.svelte
@@ -49,7 +49,7 @@ $: allowPaste = allowPaste || false;
 $: allowDrop = allowDrop || false;
 $: splitWith = splitWith || ",";
 $: autoComplete = autoComplete || false;
-$: autoCompleteFilter = typeof autoCompleteFilter == "undefined" ? true : false;
+$: autoCompleteFilter = autoCompleteFilter || false;
 $: autoCompleteKey = autoCompleteKey || false;
 $: autoCompleteMarkupKey = autoCompleteMarkupKey || false;
 $: autoCompleteIndexStart = autoCompleteStartFocused ? 0 : -1


### PR DESCRIPTION
Adding any value for the autoCompleteFilter currently turns it off, even if the value is `true`. This would give the consumer control of whether autoCompleteFilter is on or off.